### PR TITLE
therubyracer gem update

### DIFF
--- a/jslint-v8.gemspec
+++ b/jslint-v8.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |s|
 
   s.summary = %q{JSLint CLI and rake tasks via therubyracer (JavaScript V8 gem)}
   s.description = "Ruby gem wrapper for a jslint cli.  Uses the The Ruby Racer library for performance reasons targeted for usage in CI environments and backed up with a full test suite."  
-  
+
   s.files = Dir.glob("lib/**/*.rb") + Dir.glob("lib/**/*.js") + %w(Gemfile Gemfile.lock bin/jslint-v8)
   s.test_files = Dir.glob("test/**/*.rb")
 
-  s.add_dependency "therubyracer", "~> 0.9.4"
+  s.add_dependency "therubyracer", "~> 0.10.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "test-unit"
 end


### PR DESCRIPTION
working on a project using the 'less' gem and jslint. jslint-v8 requires an older version of the ruby racer so updated it. All tests passing.
